### PR TITLE
Note the attendee count in the template

### DIFF
--- a/.github/ISSUE_TEMPLATE/session-checklist.md
+++ b/.github/ISSUE_TEMPLATE/session-checklist.md
@@ -10,11 +10,12 @@ Before the session:
 - [ ] Nominate lead (chairs the session): <GITHUB HANDLE (ASSIGN TO THIS ISSUE)>
 - [ ] Nominate second (records questions and answers): <GITHUB HANDLE (ASSIGN TO THIS ISSUE)>
 - [ ] Add names to [the schedule sheet](https://csucloudservices.sharepoint.com/:x:/r/sites/StrategyUnit384/_layouts/15/Doc.aspx?sourcedoc=%7BFF59C2D9-B1F3-44AE-A04C-5D1ECE05FC5F%7D&file=RAP%20Sessions%20Schedule.xlsx)
-- [ ] Check in the schedule sheet that the session has a Teams registration link and has been shared via LinkedIn and email
+- [ ] Check in the schedule sheet that the session has been shared via LinkedIn and email
 - [ ] Publicise the link on NHS-R Slack, Teams and other channels (Bluesky, etc) if not yet done
 
 During the session:
 
+- [ ] Keep an eye on the attendee count: <ATTENDEE COUNT>
 - [ ] Welcome, state purpose and goals
 - [ ] Add the [the discussions link](https://github.com/The-Strategy-Unit/RAP_Drop_In/discussions) to the chat
 - [ ] If there are new discussion questions, see if the contributor is present and wants to talk about it, otherwise ask for questions from the room


### PR DESCRIPTION
* Add a note to the session issue template about recording the number of attendees (we lose this possibility when we move to a single joining link). Ideally this would be unique, but we may have to settle for max.
* Remove the reference to the individual Teams link in the schedule sheet (given #62).